### PR TITLE
feat(impulsoetl): :sparkles: Relatório SISAB por tipo de produção e equipe

### DIFF
--- a/src/impulsoetl/sisab/modelos.py
+++ b/src/impulsoetl/sisab/modelos.py
@@ -25,8 +25,8 @@ class TabelaProducao(object):
     _definicoes = {
         "id": "Identificador do agregado de produção no banco de dados",
         "periodo_id": "Identificador do período de realização da produção.",
-        "municipio_id": "Identificador do município responsável pela "
-        + "produção.",
+        "unidade_geografica_id": "Identificador da unidade geográfica "
+        + "responsável pela produção.",
         "tipo_producao": "Tipo de contato assistencial registrado. Pode ser "
         + "um entre 'Atendimento Individual', 'Atendimento Odontológico', "
         + "'Procedimento' ou 'Visita Domiciliar'.",
@@ -73,9 +73,9 @@ class TabelaProducao(object):
         )
 
     @declared_attr
-    def municipio_id(cls):
+    def unidade_geografica_id(cls):
         return sa.Column(
-            "municipio_id",
+            "unidade_geografica_id",
             UUID(as_uuid=False),
             # BUG: sqlalchemy.exc.NoReferencedTableError: Foreign key
             # Associado à falta do relacionamento com a tabela de período; ver
@@ -83,8 +83,8 @@ class TabelaProducao(object):
             # sa.ForeignKey("listas_de_codigos.municipios.id"),
             nullable=False,
             index=True,
-            comment=cls._definicoes["municipio_id"],
-            doc=cls._definicoes["municipio_id"],
+            comment=cls._definicoes["unidade_geografica_id"],
+            doc=cls._definicoes["unidade_geografica_id"],
         )
 
     @declared_attr

--- a/src/impulsoetl/utilitarios/textos.py
+++ b/src/impulsoetl/utilitarios/textos.py
@@ -18,7 +18,8 @@ def normalizar_texto(texto: str, separador: str = "_", caixa="baixa") -> str:
     """Normaliza o texto para caixa baixa e removendo caracteres especiais."""
     texto_limpo = re.sub("[^a-zA-Z0-9]", separador, unidecode(texto).strip())
     # garantir que não haja dois separadores seguidos
-    texto_limpo = re.sub(separador + "{2,}", separador, texto_limpo)
+    if len(separador) > 0:
+        texto_limpo = re.sub(separador + "{2,}", separador, texto_limpo)
     if caixa == "alta":
         return texto_limpo.upper()
     elif caixa == "baixa":


### PR DESCRIPTION
Introduz alterações na captura de relatórios de produção do SISAB, permitindo gerar relatórios em que o tipo de produção é uma das variáveis. Define um script para captura dos dados de produção da atenção básica relacionando o tipo de equipe ao tipo de produção realizada (e à quantidade da produção de cada tipo e equipe). Este tipo de relatório é necessário, por exemplo, para definir a quantidade de atendimentos realizados pelas equipes de Consultório na Rua.

Inclui outras pequenas alterações relacionadas aos relatórios de produção do SISAB, que estavam gerando falhas em testes.