### PR TITLE
Usar tabela `listas_de_codigos.unidades_geograficas` para obter ID impulso

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,12 +36,12 @@
   "python.pythonPath": "${workspaceFolder}/.venv/bin/python3",
   "conventionalCommits.scopes": [
     "impulsoetl",
-    "impulsoprevine"
+    "impulsoprevine",
+    "sim"
   ],
   "cSpell.diagnosticLevel": "Hint",
 
   "cSpell.language": "en,pt,pt_BR","cSpell.languageSettings": [
-    // This one works with python
     {
         "languageId": "python",
         "ignoreRegExpList": [

--- a/src/impulsoetl/comum/geografias.py
+++ b/src/impulsoetl/comum/geografias.py
@@ -53,7 +53,7 @@ BR_UFS: FrozenList[str] = FrozenList(
 
 
 ufs = tabelas["listas_de_codigos.ufs"]
-municipios = tabelas["listas_de_codigos.municipios"]
+unidades_geograficas = tabelas["listas_de_codigos.unidades_geograficas"]
 
 
 @lru_cache(27)
@@ -93,8 +93,8 @@ def id_sus_para_id_impulso(sessao: Session, id_sus: str | int) -> str:
     [`sqlalchemy.orm.session.Session`]: https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session
     """
     return (
-        sessao.query(municipios.c.id)
-        .filter(municipios.c.id_sus == str(id_sus))
+        sessao.query(unidades_geograficas.c.id)
+        .filter(unidades_geograficas.c.id_sus == str(id_sus))
         .one()[0]
     )
 
@@ -116,7 +116,7 @@ def id_impulso_para_id_sus(sessao: Session, id_impulso: str) -> str:
     [`sqlalchemy.orm.session.Session`]: https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session
     """
     return (
-        sessao.query(municipios.c.id_sus)
-        .filter(municipios.c.id == str(id_impulso))
+        sessao.query(unidades_geograficas.c.id_sus)
+        .filter(unidades_geograficas.c.id == str(unidades_geograficas))
         .one()[0]
     )

--- a/src/impulsoetl/scripts/saude_mental.py
+++ b/src/impulsoetl/scripts/saude_mental.py
@@ -122,10 +122,12 @@ def raas_disseminacao(
     logger.info(
         "Capturando RAAS Psicossociais do SIASUS.",
     )
-    operacao_id = "69bb7a34-05a8-4d9d-bc7e-c4e9e9722ece"
+    operacao_ids = [
+        "69bb7a34-05a8-4d9d-bc7e-c4e9e9722ece",
+    ]
     agendamentos_raas = (
         sessao.query(agendamentos)
-        .filter(agendamentos.c.operacao_id == operacao_id)
+        .filter(agendamentos.c.operacao_id.in_(operacao_ids))
         .all()
     )
     for agendamento in agendamentos_raas:
@@ -147,7 +149,7 @@ def raas_disseminacao(
         # a inserção de uma nova linha
         requisicao_inserir_historico = capturas_historico.insert(
             {
-                "operacao_id": operacao_id,
+                "operacao_id": agendamento.operacao_id,
                 "periodo_id": agendamento.periodo_id,
                 "unidade_geografica_id": agendamento.unidade_geografica_id,
             }
@@ -166,10 +168,13 @@ def bpa_i_disseminacao(
     logger.info(
         "Capturando BPAs individualizados do SIASUS.",
     )
-    operacao_id = "50d46e1c-7fb3-4fbb-b495-825ff1f397d9"
+    operacao_ids = [
+        "50d46e1c-7fb3-4fbb-b495-825ff1f397d9",
+        "063000e1-93e2-7c23-9bd0-1f0e7cf59178"
+    ]
     agendamentos_bpa_i = (
         sessao.query(agendamentos)
-        .filter(agendamentos.c.operacao_id == operacao_id)
+        .filter(agendamentos.c.operacao_id.in_(operacao_ids))
         .all()
     )
     for agendamento in agendamentos_bpa_i:
@@ -191,7 +196,7 @@ def bpa_i_disseminacao(
         # a inserção de uma nova linha
         requisicao_inserir_historico = capturas_historico.insert(
             {
-                "operacao_id": operacao_id,
+                "operacao_id": agendamento.operacao_id,
                 "periodo_id": agendamento.periodo_id,
                 "unidade_geografica_id": agendamento.unidade_geografica_id,
             }
@@ -210,10 +215,13 @@ def procedimentos_disseminacao(
     logger.info(
         "Capturando procedimentos ambulatoriais do SIASUS.",
     )
-    operacao_id = "f2a62b56-932a-431d-aee5-e3c0af33914f"
+    operacao_ids = [
+        "f2a62b56-932a-431d-aee5-e3c0af33914f",
+        "063000ce-23f5-7c29-a1cb-1d631ea26685",
+    ]
     agendamentos_pa = (
         sessao.query(agendamentos)
-        .filter(agendamentos.c.operacao_id == operacao_id)
+        .filter(agendamentos.c.operacao_id.in_(operacao_ids))
         .all()
     )
     for agendamento in agendamentos_pa:
@@ -235,7 +243,7 @@ def procedimentos_disseminacao(
         # a inserção de uma nova linha
         requisicao_inserir_historico = capturas_historico.insert(
             {
-                "operacao_id": operacao_id,
+                "operacao_id": agendamento.operacao_id,
                 "periodo_id": agendamento.periodo_id,
                 "unidade_geografica_id": agendamento.unidade_geografica_id,
             }

--- a/src/impulsoetl/scripts/saude_mental.py
+++ b/src/impulsoetl/scripts/saude_mental.py
@@ -178,6 +178,7 @@ def bpa_i_disseminacao(
             periodo_data_inicio=agendamento.periodo_data_inicio,
             tabela_destino=agendamento.tabela_destino,
             teste=teste,
+            **agendamento.parametros,
         )
         if teste:
             break

--- a/src/impulsoetl/scripts/saude_mental.py
+++ b/src/impulsoetl/scripts/saude_mental.py
@@ -135,6 +135,7 @@ def raas_disseminacao(
             periodo_data_inicio=agendamento.periodo_data_inicio,
             tabela_destino=agendamento.tabela_destino,
             teste=teste,
+            **agendamento.parametros,
         )
         if teste:
             break
@@ -222,6 +223,7 @@ def procedimentos_disseminacao(
             periodo_data_inicio=agendamento.periodo_data_inicio,
             tabela_destino=agendamento.tabela_destino,
             teste=teste,
+            **agendamento.parametros,
         )
         if teste:
             break

--- a/src/impulsoetl/siasus/bpa_i.py
+++ b/src/impulsoetl/siasus/bpa_i.py
@@ -209,6 +209,10 @@ def transformar_bpa_i(
     # aplica condições de filtragem dos registros
     if condicoes:
         bpa_i = bpa_i.query(condicoes)
+        logger.info(
+            "Registros após aplicar confições de filtragem: {num_registros}.",
+            num_registros=len(bpa_i),
+        )
 
     bpa_i_transformada = (
         bpa_i  # noqa: WPS221  # ignorar linha complexa no pipeline

--- a/src/impulsoetl/siasus/bpa_i.py
+++ b/src/impulsoetl/siasus/bpa_i.py
@@ -208,7 +208,7 @@ def transformar_bpa_i(
 
     # aplica condições de filtragem dos registros
     if condicoes:
-        bpa_i = bpa_i.query(condicoes)
+        bpa_i = bpa_i.query(condicoes, engine="python")
         logger.info(
             "Registros após aplicar confições de filtragem: {num_registros}.",
             num_registros=len(bpa_i),

--- a/src/impulsoetl/siasus/procedimentos.py
+++ b/src/impulsoetl/siasus/procedimentos.py
@@ -263,7 +263,7 @@ def transformar_pa(
 
     # aplica condições de filtragem dos registros
     if condicoes:
-        pa = pa.query(condicoes)
+        pa = pa.query(condicoes, engine="python")
         logger.info(
             "Registros após aplicar confições de filtragem: {num_registros}.",
             num_registros=len(pa),

--- a/src/impulsoetl/siasus/raas_ps.py
+++ b/src/impulsoetl/siasus/raas_ps.py
@@ -231,7 +231,7 @@ def transformar_raas_ps(
 
     # aplica condições de filtragem dos registros
     if condicoes:
-        raas_ps = raas_ps.query(condicoes)
+        raas_ps = raas_ps.query(condicoes, engine="python")
         logger.info(
             "Registros após aplicar confições de filtragem: {num_registros}.",
             num_registros=len(raas_ps),

--- a/src/impulsoetl/siasus/raas_ps.py
+++ b/src/impulsoetl/siasus/raas_ps.py
@@ -192,8 +192,51 @@ def extrair_raas_ps(
 def transformar_raas_ps(
     sessao: Session,
     raas_ps: pd.DataFrame,
+    condicoes: str | None = None,
 ) -> pd.DataFrame:
-    """Transforma um `DataFrame` de RAAS obtido do FTP público do DataSUS."""
+    """Transforma um `DataFrame` de RAAS obtido do FTP público do DataSUS.
+
+    Argumentos:
+        sessao: objeto [`sqlalchemy.orm.session.Session`][] que permite
+            acessar a base de dados da ImpulsoGov.
+        raas_ps: objeto [`pandas.DataFrame`][] contendo os dados de um arquivo
+            de disseminação de Registros de Ações Ambulatoriais em Saúde -
+            RAAS, conforme extraídos para uma unidade federativa e competência
+            (mês) pela função [`extrair_raas()`][].
+        condicoes: conjunto opcional de condições a serem aplicadas para
+            filtrar os registros obtidos da fonte. O valor informado deve ser
+            uma *string* com a sintaxe utilizada pelo método
+            [`pandas.DataFrame.query()`][]. Por padrão, o valor do argumento é
+            `None`, o que equivale a não aplicar filtro algum.
+
+    Note:
+        Para otimizar a performance, os filtros são aplicados antes de qualquer
+        outra transformação nos dados, de forma que as condições fornecidas
+        devem considerar que o nome, os tipos e os valores aparecem exatamente
+        como registrados no arquivo de disseminação disponibilizado no FTP
+        público do DataSUS. Verifique o [Informe Técnico][it-siasus] para mais
+        informações.
+
+    [`sqlalchemy.orm.session.Session`]: https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session
+    [`pandas.DataFrame`]: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html
+    [`extrair_bpa_i()`]: impulsoetl.siasus.raas.extrair_raas
+    [`pandas.DataFrame.query()`]: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html
+    [it-siasus]: https://drive.google.com/file/d/1DC5093njSQIhMHydYptlj2rMbrMF36y6
+    """
+
+    logger.info(
+        "Transformando DataFrame com {num_registros_raas} registros de RAAS.",
+        num_registros_raas=len(raas_ps),
+    )
+
+    # aplica condições de filtragem dos registros
+    if condicoes:
+        raas_ps = raas_ps.query(condicoes)
+        logger.info(
+            "Registros após aplicar confições de filtragem: {num_registros}.",
+            num_registros=len(raas_ps),
+        )
+
     return (
         raas_ps  # noqa: WPS221  # ignorar linha complexa no pipeline
         # renomear colunas
@@ -309,9 +352,14 @@ def obter_raas_ps(
             adicionadas à uma transação, e podem ser revertidas com uma chamada
             posterior ao método [`Session.rollback()`][] da sessão gerada com o
             SQLAlchemy.
+        \\*\\*kwargs: Parâmetros adicionais definidos no agendamento da
+            captura. Atualmente, apenas o parâmetro `condicoes` (do tipo `str`)
+            é aceito, e repassado como argumento na função
+            [`transformar_raas_ps()`][].
 
     [`sqlalchemy.orm.session.Session`]: https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session
     [`sqlalchemy.engine.Row`]: https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Row
+    [`transformar_raas_ps()`]: impulsoetl.siasus.bpa_i.transformar_raas_ps
     """
     logger.info(
         "Iniciando captura de RAAS-Psicossociais para Unidade Federativa "
@@ -334,6 +382,7 @@ def obter_raas_ps(
         raas_ps_transformada = transformar_raas_ps(
             sessao=sessao,
             raas_ps=raas_ps_lote,
+            condicoes=kwargs.get("condicoes"),
         )
 
         carregamento_status = carregar_dataframe(

--- a/tests/siasus/teste_bpa_i.py
+++ b/tests/siasus/teste_bpa_i.py
@@ -107,11 +107,15 @@ def teste_extrair_pa(uf_sigla, periodo_data_inicio, passo):
     assert len(lote_2) == 100
 
 
-@pytest.mark.integracao
-def teste_transformar_bpa_i(sessao, bpa_i):
+@pytest.mark.parametrize(
+    "condicoes",
+    ["UFMUN == '280030'", None],
+)
+def teste_transformar_bpa_i(sessao, bpa_i, condicoes):
     bpa_i_transformada = transformar_bpa_i(
         sessao=sessao,
         bpa_i=bpa_i,
+        condicoes=condicoes,
     )
 
     assert isinstance(bpa_i_transformada, pd.DataFrame)
@@ -163,12 +167,17 @@ def teste_carregar_bpa_i(
     "uf_sigla,periodo_data_inicio",
     [("SE", date(2021, 8, 1))],
 )
+@pytest.mark.parametrize(
+    "parametros",
+    [{"condicoes": "UFMUN == '280030'"}, {}],
+)
 def teste_obter_bpa_i(
     sessao,
     uf_sigla,
     periodo_data_inicio,
     caplog,
     tabela_teste,
+    parametros,
 ):
     obter_bpa_i(
         sessao=sessao,
@@ -176,6 +185,7 @@ def teste_obter_bpa_i(
         periodo_data_inicio=periodo_data_inicio,
         tabela_destino=tabela_teste,
         teste=True,
+        **parametros,
     )
 
     logs = caplog.text

--- a/tests/siasus/teste_procedimentos.py
+++ b/tests/siasus/teste_procedimentos.py
@@ -118,11 +118,15 @@ def teste_extrair_pa(uf_sigla, periodo_data_inicio, passo):
     assert len(lote_2) > 0
 
 
-@pytest.mark.integracao
-def teste_transformar_pa(sessao, pa):
+@pytest.mark.parametrize(
+    "condicoes",
+    ["PA_UFMUN == '280030'", None],
+)
+def teste_transformar_pa(sessao, pa, condicoes):
     pa_transformada = transformar_pa(
         sessao=sessao,
         pa=pa,
+        condicoes=condicoes,
     )
 
     assert isinstance(pa_transformada, pd.DataFrame)
@@ -168,12 +172,17 @@ def teste_carregar_pa(sessao, pa_transformada, caplog, tabela_teste, passo):
     "uf_sigla,periodo_data_inicio",
     [("SE", date(2021, 8, 1))],
 )
+@pytest.mark.parametrize(
+    "parametros",
+    [{"condicoes": "PA_UFMUN == '280030'"}, {}],
+)
 def teste_obter_pa(
     sessao,
     uf_sigla,
     periodo_data_inicio,
     caplog,
     tabela_teste,
+    parametros,
 ):
     obter_pa(
         sessao=sessao,
@@ -181,6 +190,7 @@ def teste_obter_pa(
         periodo_data_inicio=periodo_data_inicio,
         tabela_destino=tabela_teste,
         teste=True,
+        **parametros,
     )
 
     logs = caplog.text

--- a/tests/siasus/teste_raas_ps.py
+++ b/tests/siasus/teste_raas_ps.py
@@ -114,11 +114,15 @@ def teste_extrair_raas_ps(uf_sigla, periodo_data_inicio, passo):
     assert len(lote_2) == 100
 
 
-@pytest.mark.integracao
-def teste_transformar_raas_ps(sessao, raas_ps):
+@pytest.mark.parametrize(
+    "condicoes",
+    ["UFMUN == '280030'", None],
+)
+def teste_transformar_raas_ps(sessao, raas_ps, condicoes):
     raas_ps_transformada = transformar_raas_ps(
         sessao=sessao,
         raas_ps=raas_ps,
+        condicoes=condicoes,
     )
 
     assert isinstance(raas_ps_transformada, pd.DataFrame)
@@ -170,12 +174,17 @@ def teste_carregar_raas_ps(
     "uf_sigla,periodo_data_inicio",
     [("SE", date(2021, 8, 1))],
 )
+@pytest.mark.parametrize(
+    "parametros",
+    [{"condicoes": "UFMUN == '280030'"}, {}],
+)
 def teste_obter_raas_ps(
     sessao,
     uf_sigla,
     periodo_data_inicio,
     tabela_teste,
     caplog,
+    parametros,
 ):
     obter_raas_ps(
         sessao=sessao,
@@ -183,6 +192,7 @@ def teste_obter_raas_ps(
         periodo_data_inicio=periodo_data_inicio,
         tabela_destino=tabela_teste,
         teste=True,
+        **parametros,
     )
     sessao.commit()
 


### PR DESCRIPTION
Na função `impulsoetl.comum.geografias.id_sus_para_id_impulso()`, trocar a forma de obter o identificador único da geografia a partir de um ID SUS, consultando a tabela `listas_de_codigos.unidades_geograficas` (e não a `listas_de_codigos.municipios`) para tanto.

Isso dá mais flexibilidade à função para lidar com outras geografias que também têm ID SUS, mas não são municípios (por exemplo, Unidades Federativas e Regiões de Saúde).