### PR TITLE
Comenta funções que utilizam a biblioteca dbfread

### DIFF
--- a/src/impulsoetl/scripts/geral.py
+++ b/src/impulsoetl/scripts/geral.py
@@ -13,10 +13,11 @@ from prefect import flow
 from impulsoetl import __VERSION__
 from impulsoetl.bd import tabelas, Sessao
 
-from impulsoetl.brasilapi.cep import obter_cep
-from impulsoetl.scnes.habilitacoes import obter_habilitacoes
-from impulsoetl.scnes.vinculos import obter_vinculos
-from impulsoetl.sim.do import obter_do 
+
+#from impulsoetl.brasilapi.cep import obter_cep
+#from impulsoetl.scnes.habilitacoes import obter_habilitacoes
+#from impulsoetl.scnes.vinculos import obter_vinculos
+#from impulsoetl.sim.do import obter_do 
 from impulsoetl.loggers import habilitar_suporte_loguru, logger
 from impulsoetl.scnes.estabelecimentos_identificados.principal import obter_informacoes_estabelecimentos_identificados
 from impulsoetl.scnes.estabelecimentos_horarios.principal import obter_horarios_estabelecimentos
@@ -28,7 +29,7 @@ from impulsoetl.scnes.estabelecimentos_profissionais_totais.principal import obt
 agendamentos = tabelas["configuracoes.capturas_agendamentos"]
 capturas_historico = tabelas["configuracoes.capturas_historico"]
 
-
+"""
 @flow(
     name="Rodar Agendamentos de Habilitações do SCNES",
     description=(
@@ -246,6 +247,7 @@ def ceps(teste: bool = False) -> None:
     version=__VERSION__,
     validate_parameters=False,
 )
+"""
 def cnes_estabelecimentos_identificados(teste: bool = False,)-> None:
     
     habilitar_suporte_loguru()

--- a/src/impulsoetl/scripts/saude_mental.py
+++ b/src/impulsoetl/scripts/saude_mental.py
@@ -13,11 +13,11 @@ from prefect import flow
 from impulsoetl import __VERSION__
 from impulsoetl.bd import Sessao, tabelas
 from impulsoetl.loggers import habilitar_suporte_loguru, logger
-from impulsoetl.siasus.bpa_i import obter_bpa_i
-from impulsoetl.siasus.procedimentos import obter_pa
-from impulsoetl.siasus.raas_ps import obter_raas_ps
-from impulsoetl.sihsus.aih_rd import obter_aih_rd
-from impulsoetl.sinan.violencia import obter_agravos_violencia
+#from impulsoetl.siasus.bpa_i import obter_bpa_i
+#from impulsoetl.siasus.procedimentos import obter_pa
+#from impulsoetl.siasus.raas_ps import obter_raas_ps
+#from impulsoetl.sihsus.aih_rd import obter_aih_rd
+#from impulsoetl.sinan.violencia import obter_agravos_violencia
 from impulsoetl.sisab.relatorio_producao_resolutividade_por_condicao.principal import obter_relatorio_resolutividade_por_condicao
 from impulsoetl.sisab.relatorio_tipo_equipe_por_tipo_producao.principal import obter_relatorio_tipo_equipe_por_producao
 
@@ -154,7 +154,7 @@ def tipo_equipe_por_tipo_producao(
                 break
             sessao.commit()
             logger.info("OK.")
-
+"""
 @flow(
     name="Rodar Agendamentos de Arquivos de Disseminação da RAAS-PS",
     description=(
@@ -460,3 +460,4 @@ def agravos_violencia(
             conector.execute(requisicao_inserir_historico)
             sessao.commit()
             logger.info("OK.")
+"""


### PR DESCRIPTION
Essa alteração tem como objetivo habilitar os fluxos que não estão usando dependências da biblioteca dbfread. A construção do pacote com essa biblioteca está ocasionando problemas na construção da imagem docker no orquestrador Prefect.