### PR TITLE
refactor: :recycle: Aumenta timeouts de ETLs de SM

### DIFF
--- a/src/impulsoetl/scripts/saude_mental.py
+++ b/src/impulsoetl/scripts/saude_mental.py
@@ -224,7 +224,7 @@ def raas_disseminacao(
     ),
     retries=0,
     retry_delay_seconds=None,
-    timeout_seconds=14400,
+    timeout_seconds=54000,
     version=__VERSION__,
     validate_parameters=False,
 )
@@ -288,7 +288,7 @@ def bpa_i_disseminacao(
     ),
     retries=0,
     retry_delay_seconds=None,
-    timeout_seconds=14400,
+    timeout_seconds=54000,
     version=__VERSION__,
     validate_parameters=False,
 )
@@ -350,7 +350,7 @@ def procedimentos_disseminacao(
     ),
     retries=0,
     retry_delay_seconds=None,
-    timeout_seconds=14400,
+    timeout_seconds=54000,
     version=__VERSION__,
     validate_parameters=False,
 )


### PR DESCRIPTION
Aumenta timeout_seconds para capturas de BPA-i, AIH e Procedimentos Ambulatoriais para evitar [Errno 110] Connection timed out\n')