### PR TITLE
Corrige ETL de Indicadores do SISAB

### DIFF
--- a/src/impulsoetl/sisab/indicadores_municipios/extracao.py
+++ b/src/impulsoetl/sisab/indicadores_municipios/extracao.py
@@ -33,6 +33,25 @@ VISOES_EQUIPE_CODIGOS: Final[dict[str, str]] = {
 }
 
 
+def contar_linhas_cabecalho(resposta_requisicao, colunas_alvo):
+    """Conta o número de linhas que compõe o cabeçalho do arquivo csv"""
+
+    linhas_cabecalho = 0
+    linhas = resposta_requisicao.splitlines()
+
+    for linha in linhas:
+
+        if not linha.strip():
+            continue
+
+        if all(coluna in linha for coluna in colunas_alvo):
+            break
+
+        linhas_cabecalho += 1
+
+    return linhas_cabecalho
+
+
 def verifica_colunas(df_extraido: pd.DataFrame) -> int:
     """Verifica se 'Dataframe' possui 13 colunas como esperado"""
     return df_extraido.shape[1]
@@ -100,10 +119,23 @@ def extrair_indicadores(
         data=payload,
         timeout=120,
     )
+
+    resposta_requisicao = response.text
+    colunas_alvo = [
+        "Denominador Utilizado",
+        "Denominador Identificado",
+        "Denominador Estimado",
+        "Cadastro",
+        "Base Externa",
+    ]
+    numero_linhas_cabecalho = contar_linhas_cabecalho(
+        resposta_requisicao, colunas_alvo
+    )
+
     df_extraido = pd.read_csv(
         StringIO(response.text),
         delimiter=";",
-        header=10,
+        header=numero_linhas_cabecalho,
         encoding="ISO-8859-1",
     )
     df_extraido = df_extraido.drop(
@@ -118,4 +150,3 @@ def extrair_indicadores(
     )
 
     return df_extraido
-

--- a/src/impulsoetl/sisab/parametros_requisicao.py
+++ b/src/impulsoetl/sisab/parametros_requisicao.py
@@ -58,9 +58,9 @@ def head(url):
         "Sec-Fetch-User": "?1",
         "Sec-Fetch-Dest": "document",
         "Accept-Language": "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7",
-        "Cookie": "BIGipServerpool_sisab_jboss="
-        + cookies[0]["BIGipServerpool_sisab_jboss"]
-        + ";JSESSIONID="
-        + cookies[0]["JSESSIONID"],
+        "Cookie": "JSESSIONID="
+        + cookies[0]["JSESSIONID"]
+        + ";BIGipServerEI216T7OCd1WTwga/7fQVQ="
+        + cookies[0]["BIGipServerEI216T7OCd1WTwga/7fQVQ"],
     }
     return headers, vs


### PR DESCRIPTION

Após a divulgação dos resultados dos indicadores do 2023.Q2 pelo SISAB, identificamos a necessidade de realizar os seguintes ajustes (abordados ness PR):

1. **Ajuste dos parâmetros de captura de Cookies:** No módulo `impulsoetl.sisab.parametros_requisicao`, realizou-se um ajuste nos parâmetros responsáveis por capturar os cookies do cabeçalho da requisição. 

2. **Criação de função dinâmica de identificação de tamanho de cabeçalho:** No módulo `impulsoetl.sisab.indicadores_municipios.extracao`, introduziu-se uma nova função que torna dinâmica a identificação do tamanho do cabeçalho dos arquivos CSV baixados para os indicadores. Essa melhoria permite que o sistema se adapte automaticamente a diferentes formatos de cabeçalho, garantindo uma extração de dados mais robusta e flexível.

